### PR TITLE
Fix values and nginx template for non-https deployment

### DIFF
--- a/contrib/helm-charts/portus/templates/nginx-configmap.yaml
+++ b/contrib/helm-charts/portus/templates/nginx-configmap.yaml
@@ -42,7 +42,7 @@ data:
         '' 'registry/2.0';
       }
 
-      upstream {{ template "portus.fullname" . }} {
+      upstream {{ template "portus.fullname" . }}:{{ .Values.portus.service.port }} {
         least_conn;
         server {{ template "portus.fullname" . }}:{{ .Values.portus.service.port }} max_fails=3 fail_timeout=15s;
       }
@@ -87,7 +87,7 @@ data:
         # http://blog.ivanristic.com/2013/08/configuring-apache-nginx-and-openssl-for-forward-secrecy.html
         ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
         {{- else }}
-        listen {{ .Values.nginx.service.port }} http2;
+        listen {{ .Values.nginx.service.port }} ;
         {{- end }}
 
         ##
@@ -162,9 +162,9 @@ data:
         # Portus needs to handle /v2/token for authentication
         location = /v2/token {
           {{- if .Values.portus.tls.enabled }}
-          proxy_pass https://{{ template "portus.fullname" . }};
+          proxy_pass https://{{ template "portus.fullname" . }}:{{ .Values.portus.service.port }};
           {{- else }}
-          proxy_pass http://{{ template "portus.fullname" . }};
+          proxy_pass http://{{ template "portus.fullname" . }}:{{ .Values.portus.service.port }};
           {{- end }}
 
           proxy_set_header Host $http_host;   # required for docker client's sake
@@ -178,9 +178,9 @@ data:
         # Portus needs to handle /v2/webhooks/events for notifications
         location = /v2/webhooks/events {
           {{- if .Values.portus.tls.enabled }}
-          proxy_pass https://{{ template "portus.fullname" . }};
+          proxy_pass https://{{ template "portus.fullname" . }}:{{ .Values.portus.service.port }};
           {{- else }}
-          proxy_pass http://{{ template "portus.fullname" . }};
+          proxy_pass http://{{ template "portus.fullname" . }}:{{ .Values.portus.service.port }};
           {{- end }}
 
           proxy_set_header Host $http_host;   # required for docker client's sake
@@ -198,9 +198,9 @@ data:
 
         location @{{ template "portus.fullname" . }} {
           {{- if .Values.portus.tls.enabled }}
-          proxy_pass https://{{ template "portus.fullname" . }};
+          proxy_pass https://{{ template "portus.fullname" . }}:{{ .Values.portus.service.port }};
           {{- else }}
-          proxy_pass http://{{ template "portus.fullname" . }};
+          proxy_pass http://{{ template "portus.fullname" . }}:{{ .Values.portus.service.port }};
           {{- end }}
 
           proxy_set_header Host $http_host;   # required for docker client's sake

--- a/contrib/helm-charts/portus/values.yaml
+++ b/contrib/helm-charts/portus/values.yaml
@@ -256,38 +256,39 @@ nginx:
     ##
     type: "ClusterIP"
 
-    port:
+    port: 80
     # nodePort:
 
     ## Annotation to be added to the service
     ##
     annotations:
-    #   kubernetes.io/ingress.class: "nginx"
+      kubernetes.io/ingress.class: "nginx"
 
   ## in order to access the docker registry from outside of the cluster
   ## if ingress is enabled set host to the domain you are using
   ## if NodePort is being used set host to the ip address of a cluster node
   ##
-  # host:
+  host: registry.10.22.12.3.nip.io
 
   ## ingress configuration.
   ##
   ingress:
-    enabled: false
+    enabled: "true"
 
     ## Anntations to be added to the web ingress
     ##
-    # annotations:
-    #   kubernetes.io/ingress.class: "nginx"
-    #   nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    #   kubernetes.io/ingress.allow-http: "false"
-    #   ingress.kubernetes.io/ssl-passthrough: "true"
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+#      kubernetes.io/ingress.allow-http: "true"
+#      ingress.kubernetes.io/ssl-passthrough: "true"
+#      nginx.ingress.kubernetes.io/secure-backends: "true"
 
     ## TLS configuration
     ## the ingress host must be covered by the key/cert in order for TLS to work properly
     ##
-    # tls:
-    #   enabled: false
+    tls:
+      enabled: false
 
       ## Secrets containing SSL key and cert must be manually created in the namespace
       ##


### PR DESCRIPTION
In some cases undefined values lead to deployment errors 
even if those values were not used (e.g. the secrets, where I use 
dummy values). Removing http/2 from nginx, and added ports.
Yours, Steffen